### PR TITLE
added support for adding an indicator to the calendar

### DIFF
--- a/MDCalendar/MDCalendar.h
+++ b/MDCalendar/MDCalendar.h
@@ -97,6 +97,7 @@
 @property (nonatomic, strong) UIColor *weekdayTextColor;        /**< Default is textColor */
 
 @property (nonatomic, strong) UIColor *cellBackgroundColor;     /**< Default is no background color for individual cells */
+@property (nonatomic, strong) UIColor *indicatorColor;          /**< Default is light gray */
 @property (nonatomic, strong) UIColor *highlightColor;          /**< Default is tint color */
 
 
@@ -149,4 +150,5 @@
 @optional
 - (void)calendarView:(MDCalendar *)calendarView didSelectDate:(NSDate *)date;
 - (BOOL)calendarView:(MDCalendar *)calendarView shouldSelectDate:(NSDate *)date;
+- (BOOL)calendarView:(MDCalendar *)calendarView shouldShowIndicatorForDate:(NSDate *)date;
 @end

--- a/MDCalendar/MDCalendar.m
+++ b/MDCalendar/MDCalendar.m
@@ -33,12 +33,14 @@
 
 @property (nonatomic, assign) CGFloat  borderHeight;
 @property (nonatomic, assign) UIColor *borderColor;
+@property (nonatomic, assign) UIColor *indicatorColor;
 @end
 
 @interface MDCalendarViewCell  ()
 @property (nonatomic, strong) UILabel *label;
 @property (nonatomic, strong) UIView  *highlightView;
 @property (nonatomic, strong) UIView  *borderView;
+@property (nonatomic, strong) UIView  *indicatorView;
 @end
 
 static NSString * const kMDCalendarViewCellIdentifier = @"kMDCalendarViewCellIdentifier";
@@ -60,10 +62,15 @@ static NSString * const kMDCalendarViewCellIdentifier = @"kMDCalendarViewCellIde
         UIView *bottomBorderView = [[UIView alloc] initWithFrame:CGRectZero];
         bottomBorderView.hidden = YES;
         self.borderView = bottomBorderView;
+
+        UIView *indicatorView = [[UIView alloc] initWithFrame:CGRectZero];
+        indicatorView.hidden = YES;
+        self.indicatorView = indicatorView;
         
         [self.contentView addSubview:highlightView];
         [self.contentView addSubview:label];
         [self.contentView addSubview:bottomBorderView];
+        [self.contentView addSubview:indicatorView];
 
     }
     return self;
@@ -89,6 +96,11 @@ static NSString * const kMDCalendarViewCellIdentifier = @"kMDCalendarViewCellIde
 - (void)setBorderColor:(UIColor *)borderColor {
     _borderView.backgroundColor = borderColor;
     _borderView.hidden = NO;
+}
+
+- (void)setIndicatorColor:(UIColor *)indicatorColor {
+    _indicatorView.backgroundColor = indicatorColor;
+    _indicatorView.hidden = NO;
 }
 
 - (void)setSelected:(BOOL)selected {
@@ -124,6 +136,13 @@ static NSString * const kMDCalendarViewCellIdentifier = @"kMDCalendarViewCellIde
     _highlightView.layer.cornerRadius = CGRectGetHeight(_highlightView.bounds) / 2;
     
     _borderView.frame = CGRectMake(0, 0, viewSize.width, self.borderHeight);
+
+    CGFloat dotInset = viewSize.height * 0.45f;
+    CGRect indicatorFrame = CGRectInset(self.contentView.frame, dotInset, dotInset);
+    indicatorFrame.origin.y = _highlightView.frame.origin.y + _highlightView.frame.size.height - indicatorFrame.size.height * 1.5;
+    _indicatorView.frame = indicatorFrame;
+    _indicatorView.layer.cornerRadius = CGRectGetHeight(_indicatorView.bounds) / 2;
+
 }
 
 - (void)prepareForReuse {
@@ -405,6 +424,7 @@ static CGFloat const kMDCalendarViewSectionSpacing = 10.f;
         
         self.cellBackgroundColor    = nil;
         self.highlightColor         = self.tintColor;
+        self.indicatorColor         = [UIColor lightGrayColor];
         
         self.headerBackgroundColor  = nil;
         self.headerFont             = [UIFont systemFontOfSize:20];
@@ -564,6 +584,11 @@ static CGFloat const kMDCalendarViewSectionSpacing = 10.f;
     cell.borderHeight = self.borderHeight;
     cell.borderColor = self.borderColor;
     
+    BOOL showIndicator = NO;
+    if ([_delegate respondsToSelector:@selector(calendarView:shouldShowIndicatorForDate:)]) {
+        showIndicator = [_delegate calendarView:self shouldShowIndicatorForDate:date];
+    }
+    
     NSInteger sectionMonth = [self monthForSection:indexPath.section];
     
     cell.userInteractionEnabled = [self collectionView:collectionView shouldSelectItemAtIndexPath:indexPath] ? YES : NO;
@@ -580,6 +605,7 @@ static CGFloat const kMDCalendarViewSectionSpacing = 10.f;
             cell.backgroundColor = [cell.backgroundColor colorWithAlphaComponent:0.2];
         } else {
             cell.label.text = @"";
+            showIndicator = NO;
         }
         cell.userInteractionEnabled = NO;
     } else if ([date isEqualToDateSansTime:self.selectedDate]) {
@@ -587,6 +613,8 @@ static CGFloat const kMDCalendarViewSectionSpacing = 10.f;
         cell.selected = YES;
         [collectionView selectItemAtIndexPath:indexPath animated:YES scrollPosition:UICollectionViewScrollPositionNone];
     }
+    
+    cell.indicatorColor = showIndicator ? self.indicatorColor : [UIColor clearColor];
     
     return cell;
 }

--- a/MDCalendarDemo/MDCalendarViewController.m
+++ b/MDCalendarDemo/MDCalendarViewController.m
@@ -57,6 +57,7 @@
         calendarView.cellBackgroundColor = [UIColor whiteColor];
         
         calendarView.highlightColor = [UIColor pacifica];
+        calendarView.indicatorColor = [UIColor colorWithWhite:0.85 alpha:1.0];
         
         NSDate *startDate = [NSDate date];
         NSDate *endDate = [startDate dateByAddingMonths:12*25];
@@ -83,6 +84,12 @@
 
 - (void)calendarView:(MDCalendar *)calendarView didSelectDate:(NSDate *)date {
     NSLog(@"Selected Date: %@", [date descriptionWithLocale:[NSLocale currentLocale]]);
+}
+
+- (BOOL) calendarView:(MDCalendar *)calendarView shouldShowIndicatorForDate:(NSDate *)date
+{
+    // show indicator for every 4th day
+    return [date day] % 4 == 1;
 }
 
 @end


### PR DESCRIPTION
I like your calendar picker.   It's clean, fast, easy to use and works well.   I'm working on a project that needs a calendar picker like this.   However, I need the ability to show an indicator on the calendar on a date by date basis, similar to how the iOS7 calendar app displays one.

I've added a new view to the cell that displays a tiny dot under the date and extended the delegate protocol.

I've also updated the demo app to show an indicator on every 4th day.
